### PR TITLE
Prevent duplication of image pixel buffer creation for sharp

### DIFF
--- a/lib/HvcP2.js
+++ b/lib/HvcP2.js
@@ -1,6 +1,6 @@
 /* ------------------------------------------------------------------
 * node-omron-hvc-p2 - HvcP2.js
-* Date: 2017-11-04
+* Date: 2018-02-14
 * ---------------------------------------------------------------- */
 'use strict';
 const mFs = require('fs');
@@ -482,7 +482,8 @@ HvcP2.prototype.detect = function(params) {
 					width  : res['image']['width'],
 					height : res['image']['height'],
 					pixels : res['image']['pixels'],
-					type   : params['imageType']
+					type   : params['imageType'],
+					buffer : res['image']['buffer']
 				};
 				if('imageFormat' in params) {
 					opts['format'] = params['imageFormat'];

--- a/lib/HvcP2Command.js
+++ b/lib/HvcP2Command.js
@@ -1,6 +1,6 @@
 /* ------------------------------------------------------------------
 * node-omron-hvc-p2 - HvcP2Command.js
-* Date: 2017-06-23
+* Date: 2018-02-14
 * ---------------------------------------------------------------- */
 'use strict';
 
@@ -459,14 +459,17 @@ HvcP2Command.prototype._parse04 = function(buf, p) {
 		let height = buf.readUInt16LE(offset + 2);
 		let image_buf = buf.slice(offset + 4);
 		let pixels = [];
+		// we could skip pixels and stay with the buffer if we move just to sharp - revisit
 		for(let i=0; i<image_buf.length; i++) {
 			pixels.push(image_buf.readUInt8(i));
 		}
 		data['image'] = {
 			width : width,
 			height: height,
-			pixels: pixels
+			pixels: pixels,
+			buffer: image_buf
 		};
+	
 	}
 	//
 	return {data: data};

--- a/lib/HvcP2Image.js
+++ b/lib/HvcP2Image.js
@@ -1,11 +1,11 @@
 /* ------------------------------------------------------------------
 * node-omron-hvc-p2 - HvcP2Image.js
-* Date: 2017-06-19
+* Date: 2018-02-14
 * ---------------------------------------------------------------- */
 'use strict';
 const mFs = require('fs');
 
-// Defacto for linux/os x - stop by Punk Ave and give Tom Boutell a cookie next time I'm in Center City ;)
+// Defacto for linux/os x - stop by Punk Ave and give Tom Boutell a cookie next time I'm in Center City Philly ;)
 let mGd = null;
 try {
 	mGd = require('node-gd');
@@ -74,7 +74,7 @@ HvcP2Image.prototype.conv = function(params, result) {
 		}
 
 		let p = {};
-
+		
 		// width
 		if('width' in params) {
 			let v = params['width'];
@@ -102,8 +102,23 @@ HvcP2Image.prototype.conv = function(params, result) {
 			reject(new Error('The parameter `height` is required.'));
 			return;
 		}
-
-		// pixels
+		
+		// buffer
+		if('buffer' in params) {
+			let v = params['buffer']
+			if(Buffer.isBuffer(v) && v.length > 0) {
+				p['buffer'] = v;
+			} else {
+				reject(new Error('The parameter `buffer` must be an Buffer object.'));
+				return;
+			}
+		} else {
+			reject(new Error('The parameter `buffer` is required.'));
+			return;
+		}
+		
+		
+		// pixels - we could optimize and skip this and the pixel creation in command - do that!
 		if('pixels' in params) {
 			let v = params['pixels']
 			if(Array.isArray(v) && v.length > 0) {
@@ -131,7 +146,7 @@ HvcP2Image.prototype.conv = function(params, result) {
 			return;
 		}
 
-		// format
+		// format (reivist for support diffs between node-gd, lwip, jim, sharp)
 		if('format' in params) {
 			let v = params['format'];
 			if(typeof(v) === 'string' && v.match(/^(gif|jpg|png)$/)) {
@@ -173,30 +188,35 @@ HvcP2Image.prototype.conv = function(params, result) {
 			p['marker'] = false;
 		}
 
-		if(mGd) {
+		// Re-ordered this - to allow fall through order based on performance, first sharp, then gd, then lwip, then jimp... based on perf numbers found here:
+		// http://sharp.pixelplumbing.com/en/stable/performance/
+		
+		if(sharp) {
+			this._convArrayToImageSharp(p, result).then((result) => {
+				resolve(result);
+			}).catch((error) => {
+				reject(error);
+			});	
+		} else if(mGd) {
 			this._convArrayToImageGd(p, result).then((result) => {
 				resolve(result);
 			}).catch((error) => {
 				reject(error);
 			});
-		} else if (Jimp) {
-		
-		this._convArrayToImageJimp(p, result).then((result) => {
-				resolve(result);
-			}).catch((error) => {
-				reject(error);
-			});
-		
 		} else if(mLwip) {
 			this._convArrayToImageLwip(p, result).then((result) => {
 				resolve(result);
 			}).catch((error) => {
 				reject(error);
 			});
-			
-		// add in Sharp here next...
+		} else if(Jimp) {
+			this._convArrayToImageJimp(p, result).then((result) => {
+				resolve(result);
+			}).catch((error) => {
+				reject(error);
+			});
 		} else {
-			reject(new Error('The node module `node-gd` or `lwip` must be installed.'));
+			reject(new Error('At least one of the OS appropriate node modules `node-gd`, `sharp`, `lwip`, or `jimp` must be installed.'));
 			return;
 		}
 	});
@@ -545,6 +565,176 @@ HvcP2Image.prototype._convArrayToImageJimp = function(p, result) {
 	return promise;
 };
 
+// Sharp stuff - no markers or text yet - coming next
+HvcP2Image.prototype._convArrayToImageSharp = function(p, result) {
+	
+	//console.log(p['pixels']);
+	
+	var mypath = process.cwd();
+	
+	let promise = new Promise((resolve, reject) => {
+	
+		let _this = this;
+		
+		//console.log(p['pixels']);
+		//console.log(p);
+
+		
+			//require('path').dirname(require.main.filename)
+			//var mypath = process.cwd();
+			mypath += "/data/image.";
+			
+			let fpath = mypath;
+			
+			let saveFile = null;
+						
+			/*
+			var n = p['height']*p['width'], data = new Uint8Array(n);
+			console.time("LOOP");
+			var i=0;
+			for (i=0; i<n; i++) {
+				data[i] = p["pixels"][i];
+			}
+			console.timeEnd("LOOP");
+			console.log(p['buffer']);
+			//console.log(new Buffer(data.buffer));
+			*/
+		
+		
+		//new Buffer(data.buffer)
+		var image = new sharp(p['buffer'], { raw: { width: p['width'], height: p['height'], channels: 1} }).png().toFile(fpath+p['format'], function(err, info) {
+				//console.log(info);
+				if(err) {
+					console.log(err);
+					reject(err);
+					return;
+				}
+		  });
+		
+		/*
+		({
+		
+		create: {
+			width: p['width'],
+			height: p['height']}
+			channels: 1,
+			background: { r: 0, g: 0, b: 0, alpha: 255 }
+			}
+		
+		});
+		*/
+	
+		
+		
+			// markers, etc. do them here...
+			/* REVISIT MARKERS!
+			if(p['marker'] === true) {
+				let w = 1600;
+				let h = 1200;
+				if(p['width'] < p['height']) {
+					w = 1200;
+					h = 1600;
+				}
+				if('hand' in result) {
+					result['hand'].forEach((o) => {
+						let x = o['x'];
+						let y = o['y'];
+						let s = o['size'];
+						let sh = s / 2;
+						let color = 0xffff00;
+						image.rectangle(
+							Math.round(p['width'] * (x - sh) / w),
+							Math.round(p['height'] * (y - sh) / h),
+							Math.round(p['width'] * (x + sh) / w),
+							Math.round(p['height'] * (y + sh) / h),
+							color
+						);
+					});
+				}
+				if('body' in result) {
+					result['body'].forEach((o) => {
+						let x = o['x'];
+						let y = o['y'];
+						let s = o['size'];
+						let sh = s / 2;
+						let color = 0x00ff00;
+						image.rectangle(
+							Math.round(p['width'] * (x - sh) / w),
+							Math.round(p['height'] * (y - sh) / h),
+							Math.round(p['width'] * (x + sh) / w),
+							Math.round(p['height'] * (y + sh) / h),
+							color
+						);
+					});
+				}
+				
+				if('face' in result) {
+					result['face'].forEach((o) => {
+						if('face' in o) {
+							let x = o['face']['x'];
+							let y = o['face']['y'];
+							let s = o['face']['size'];
+							let sh = s / 2;
+							let color = 0x00ff00;
+							if('gender' in o) {
+								if(o['gender']['gender'] === 1) {
+									color = 0x0000ff;
+								} else if(o['gender']['gender'] === 0) {
+									color = 0xff0000;
+								}
+							}
+							let x1 = Math.round(p['width'] * (x - sh) / w);
+							let y1 = Math.round(p['height'] * (y - sh) / h);
+							let x2 = Math.round(p['width'] * (x + sh) / w);
+							let y2 = Math.round(p['height'] * (y + sh) / h);
+							image.rectangle(x1, y1, x2, y2, color);
+							if('age' in o) {
+								let string = 'Age:' + o['age']['age'].toString();
+								let font = mypath+"/fonts/FreeMono.ttf";
+								if(mFs.existsSync(font)) {
+									image.stringFT(color, font, 12, 0, x1, y1-4, string, false);
+								}
+							}
+						}
+					});
+				}
+			}
+			*/
+			
+			
+			
+				
+				if(p['type'] === 1 || p['type'] === 2) {
+					mFs.open(fpath+p['format'] , 'r', (error, fd) => {
+						if(error) {
+							reject(error);
+							return;
+						}
+						mFs.fstat(fd, (error, stats) => {
+							let fsize = stats['size'];
+							let buf = Buffer.alloc(fsize);
+							mFs.read(fd, buf, 0, fsize, 0, (error, bytes, buffer) => {
+								mFs.close(fd, () => {
+									if(error) {
+										reject(error);
+										return;
+									}
+									if(p['type'] === 1) {
+										resolve(buffer);
+									} else if(p['type'] === 2) {
+										resolve('data:image/' + p['format'] + ';base64,' + buffer.toString('base64'));
+									}
+								});
+							});
+						});
+					});
+				} else {
+					resolve();
+				}
+			});
+		
+	return promise;
+};
 
 
 // LWIP - deprecate at some point - poor performance from lwip and jimp - move to sharp ASAP


### PR DESCRIPTION
Sharp can use buffer as source, so don’t re-iterate through the pixel
array to create a buffer, just pass it from the original result parse
from the detect command result parse. Consider dropping pixels and use
only buffer with sharp for better performance…